### PR TITLE
Update to use External Client App instead of Connected App

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -52,7 +52,7 @@ paths:
             isPii: true  # Optional, depending on whether the `name` should be considered PII
         heroku:
           authorization:
-            connectedApp: BadgeServiceConnectedApp
+            externalClientApp: BadgeServiceExternalClientApp
             permissionSet: BadgeServicePermissions
 
 components: {}


### PR DESCRIPTION
Updates the API specification to use Salesforce External Client Apps instead of Connected Apps, following [Salesforce's Spring '26 changes](https://help.salesforce.com/s/articleView?id=005228017&type=1).

## Changes

- Updated `api-spec.yaml` to use `externalClientApp: BadgeServiceExternalClientApp` instead of `connectedApp: BadgeServiceConnectedApp`

## Context

As of Salesforce Spring '26, new connected apps can no longer be created. This change updates the example to use external client apps, which is now the recommended approach for new integrations.

## Backward Compatibility

Existing implementations using connected apps will continue to work. This change only affects new installations following this tutorial.